### PR TITLE
Fix assets compilation failing

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,8 +26,9 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
-  # Compress CSS using a preprocessor.
-  # config.assets.css_compressor = :sass
+  # There's a compatibility issue if you turn Sass on,
+  # because SassC doesn't understand the modern CSS syntax used by Tailwind. Defaulting to nil
+  config.assets.css_compressor = nil
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,6 +54,10 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
+  # There's a compatibility issue if you turn Sass on,
+  # because SassC doesn't understand the modern CSS syntax used by Tailwind. Defaulting to nil
+  config.assets.css_compressor = nil
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/spec/tasks/assets_precompile_spec.rb
+++ b/spec/tasks/assets_precompile_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+require 'rake'
+
+Rails.application.load_tasks if Rake::Task.tasks.empty?
+
+RSpec.describe "assets", type: :task do
+  describe 'rake assets:precompile' do
+    let(:task) { Rake::Task["assets:precompile"] }
+
+    it 'does not throw an error when disabling css compressor' do
+      expect { task.invoke }.not_to raise_error
+    end
+
+    it 'makes sure that compressor is disabled in production' do
+      file = File.read("config/environments/production.rb")
+      expect(file).to include("config.assets.css_compressor = nil")
+    end
+  end
+end

--- a/spec/tasks/assets_precompile_spec.rb
+++ b/spec/tasks/assets_precompile_spec.rb
@@ -1,17 +1,19 @@
-require 'rails_helper'
-require 'rake'
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
 
 Rails.application.load_tasks if Rake::Task.tasks.empty?
 
 RSpec.describe "assets", type: :task do
-  describe 'rake assets:precompile' do
+  describe "rake assets:precompile" do
     let(:task) { Rake::Task["assets:precompile"] }
 
-    it 'does not throw an error when disabling css compressor' do
+    it "does not throw an error when disabling css compressor" do
       expect { task.invoke }.not_to raise_error
     end
 
-    it 'makes sure that compressor is disabled in production' do
+    it "makes sure that compressor is disabled in production" do
       file = File.read("config/environments/production.rb")
       expect(file).to include("config.assets.css_compressor = nil")
     end


### PR DESCRIPTION
Assets compilation was failing because tailwind css is trying to be compressed by sassc. Read: https://github.com/thoughtbot/administrate/issues/2091

I have updated test and production enviroments and added a test that checks that no errors ocurs on the precompile task and that production config is matching tests in this specific scenario